### PR TITLE
feat(webp): 可选 --all-frame=1 启用全帧转换

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ go run main.go --tool=avif --dir=/Users/admin/Documents/png --quality=60
 
 go run main.go --tool=webp --dir=/Users/admin/Documents/png --quality=80
 
+多帧/动画源（如动图）需写出完整动画 webp 时，加上 `--all-frame=1`（会传给 vips 的 `[n=-1]`；默认不加，只处理首帧）：
+
+go run main.go --tool=webp --dir=/Users/admin/Documents/png --quality=80 --all-frame=1
+
 批量转 heic：
 
 go run main.go --tool=heic --dir=/Users/admin/Documents/png --quality=50

--- a/img/index.go
+++ b/img/index.go
@@ -55,17 +55,20 @@ var cfgItem cfgMapItem
 var lock = sync.Mutex{}
 var doneNum = 0
 var quality string
+var webpAllFrames bool
 
 type Props struct {
-	Type    string
-	Dir     string
-	Quality string
+	Type     string
+	Dir      string
+	Quality  string
+	AllFrame bool
 }
 
 func Main(props Props) {
 	println(props.Type)
 	cfgItem = cfgMap[props.Type]
 	quality = cfgItem.quality
+	webpAllFrames = props.AllFrame
 
 	if props.Quality != "" {
 		quality = props.Quality
@@ -155,7 +158,11 @@ func handleFile(file *utils.FileItem, targetDir string, fileList []*utils.FileIt
 		cmd = exec.Command("vips", "heifsave", file.Path, targetFilePath, fmt.Sprintf("--Q=%s", quality), "--effort=9")
 	case "webp":
 		println("webp")
-		cmd = exec.Command("vips", "webpsave", file.Path+"[n=-1]", targetFilePath, fmt.Sprintf("--Q=%s", quality), "--effort=6")
+		src := file.Path
+		if webpAllFrames {
+			src = file.Path + "[n=-1]"
+		}
+		cmd = exec.Command("vips", "webpsave", src, targetFilePath, fmt.Sprintf("--Q=%s", quality), "--effort=6")
 	case "avif":
 		// [n=-1] 加载全部帧。动画 AVIF 写出依赖 libheif；多数当前版本仍只能得到单帧（libvips#3629）。
 		cmd = exec.Command("vips", "heifsave", file.Path, targetFilePath, fmt.Sprintf("--Q=%s", quality), "--effort=9", "--compression=av1", "--subsample-mode=on")

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 	// img
 	dir := flag.String("dir", "", "处理目录")
 	quality := flag.String("quality", "", "处理目录")
+	allFrame := flag.Int("all-frame", 0, "webp：1 时加载全部帧写入动画 webp（默认 0 仅首帧）")
 
 	flag.Parse()
 
@@ -47,9 +48,10 @@ func main() {
 		ssq.Main(ssq.Props{Num: *num})
 	case "heic", "webp", "avif":
 		img.Main(img.Props{
-			Dir:     *dir,
-			Quality: *quality,
-			Type:    *tool,
+			Dir:      *dir,
+			Quality:  *quality,
+			Type:     *tool,
+			AllFrame: *allFrame == 1,
 		})
 	case "filetime":
 		filetime.Main(filetime.Props{Dir: *dir})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

- 新增命令行参数 `--all-frame`（整型，默认 `0`）。仅当 `--all-frame=1` 时，webp 转换在输入路径后附加 `[n=-1]`，由 libvips 加载全部帧写出动画 webp；默认不加后缀，仅处理首帧。
- `README.md` 补充了该参数及示例命令。

## 涉及文件

- `main.go`：定义 `all-frame` flag 并传入 `img.Props`
- `img/index.go`：根据 `AllFrame` 决定是否拼接 `[n=-1]`
- `README.md`：文档更新
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-129f0b0f-d760-4028-afe7-0df81663ca4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-129f0b0f-d760-4028-afe7-0df81663ca4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

